### PR TITLE
Fix a problem when we use a file with a name different of the original name proposed

### DIFF
--- a/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
@@ -46,14 +46,14 @@ EOT
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $source = $input->getArgument('source');
+        // Get the path to write the file from the configuration.
+        $destination = $this->getApplication()->getKernel()->getContainer()->getParameter('maxmind_geoip_data_file_path');
+        $destinationBeforeUnzip = sprintf('%s/%s', dirname($destination), basename($source));
 
-        $bundlePath = $this->getApplication()->getKernel()->getBundle('MaxmindGeoipBundle')->getPath();
-        $dataDir = sprintf('%s', $bundlePath.'/../../../../data/');
-        $filename = basename($source);
-        $destination = sprintf('%s/%s', $dataDir, $filename);
+
         $output->writeln(sprintf('Start downloading %s', $source));
         $output->writeln('...');
-        if (!copy($source, $destination)) {
+        if (!copy($source, $destinationBeforeUnzip)) {
             $output->writeln('<error>Error during file download occured</error>');
 
             return 1;
@@ -62,7 +62,13 @@ EOT
         $output->writeln('<info>Download completed</info>');
         $output->writeln('Unzip the downloading data');
         $output->writeln('...');
-        system('gunzip -f "'.$destination.'"');
+        system('gunzip -fc "'.$destinationBeforeUnzip.'" > "'.$destination.'"');
         $output->writeln('<info>Unzip completed</info>');
+        $successDeleteFileZip = unlink($destinationBeforeUnzip);
+        if (!$successDeleteFileZip) {
+            $output->writeln('<error>Error to delete the original file after unzip</error>');
+
+            return 1;
+        }
     }
 }

--- a/src/Maxmind/Bundle/GeoipBundle/Service/GeoipManager.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Service/GeoipManager.php
@@ -9,19 +9,20 @@ use Maxmind\lib\GeoIpRegionVars;
 
 class GeoipManager
 {
+    protected $filePath = '';
+
     protected $geoip = null;
 
     protected $record = null;
 
     public function __construct(Kernel $kernel)
     {
-    	$filePath = $kernel->getContainer()->getParameter('maxmind_geoip_data_file_path');
-        $this->geoip = new GeoIp($filePath);
+        $this->filePath = $kernel->getContainer()->getParameter('maxmind_geoip_data_file_path');
     }
 
     public function lookup($ip)
     {
-        $this->record = $this->geoip->geoip_record_by_addr($ip);
+        $this->record = $this->getGeoIp()->geoip_record_by_addr($ip);
 
         if ($this->record)
             return $this;
@@ -165,5 +166,19 @@ class GeoipManager
             return $this->record->continent_code;
 
         return $this->record;
+    }
+
+    /**
+     * Get the current geoip instance.
+     *
+     * @return GeoIp
+     */
+    protected function getGeoIp()
+    {
+        if (is_null($this->geoip)) {
+            $this->geoip = new GeoIp($this->filePath);
+        }
+
+        return $this->geoip;
     }
 }


### PR DESCRIPTION
Use the config to create the data file. Open the data file only when it is used and not in the __construct.
